### PR TITLE
Add e2e test for AZ aware functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# TODO need to make a 'clean' target for removing the cluster resources and local files
 # Image URL to use all building/pushing image targets
 IMG ?= docker-registry.zooz.co:4567/payu-clan-sre/redis/redis-operator/redis-operator-docker
 DEV_IMAGE ?= redis-operator:dev
@@ -43,9 +44,8 @@ test: generate fmt vet manifests
 	go test ./... -coverprofile cover.out
 
 # Run e2e tests
-e2e-test: IMG=redis-operator-docker:local
-e2e-test: docker-build docker-build-local-redis kind-load-redis kind-load-controller
-	cd test/e2e && go test -count=1 ./... -tags=e2e_redis_op
+e2e-test-setup: IMG=redis-operator-docker:local
+e2e-test-setup: docker-build docker-build-local-redis kind-load-redis kind-load-controller
 
 # Build manager binary
 manager: generate fmt vet

--- a/go.sum
+++ b/go.sum
@@ -621,6 +621,7 @@ k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
 k8s.io/apimachinery v0.18.6/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
 k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/apimachinery v0.19.2/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
+k8s.io/apimachinery v0.19.3 h1:bpIQXlKjB4cB/oNpnNnV+BybGPR7iP5oYpsOTEJ4hgc=
 k8s.io/apiserver v0.18.6/go.mod h1:Zt2XvTHuaZjBz6EFYzpp+X4hTmgWGy8AthNVnTdm3Wg=
 k8s.io/apiserver v0.19.2/go.mod h1:FreAq0bJ2vtZFj9Ago/X0oNGC51GfubKK/ViOKfVAOA=
 k8s.io/client-go v0.18.6 h1:I+oWqJbibLSGsZj8Xs8F0aWVXJVIoUHWaaJV3kUN/Zw=

--- a/hack/cloud.yaml
+++ b/hack/cloud.yaml
@@ -2,9 +2,9 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -12,7 +12,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1a"
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -20,7 +20,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1a"
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -28,7 +28,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1a"
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -36,7 +36,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1b"
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -44,7 +44,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1b"
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -52,7 +52,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1b"
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -60,7 +60,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1c"
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -68,7 +68,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1c"
 - role: worker
-  image: kindest/node:v1.15.12
+  image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration

--- a/hack/gen_kind_config.py
+++ b/hack/gen_kind_config.py
@@ -5,7 +5,7 @@ class ClusterParams:
     NODE_LAYOUT = [['eu-central-1a']*3, ['eu-central-1b']*3, ['eu-central-1c']*3]
     ZONE_KEY = 'failure-domain.beta.kubernetes.io/zone'
     KIND_API_VERSION = 'kind.x-k8s.io/v1alpha4'
-    KUBERNETES_VERSION = 'v1.15.12'
+    KUBERNETES_VERSION = 'v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20'
     # KUBERNETES_VERSION = 'v1.17.11'
 
 def get_node_count():

--- a/test/README.md
+++ b/test/README.md
@@ -6,7 +6,7 @@ End-to-end automated testing for the Redis cluster.
 
 ### How it works
 
-The tests use a framework that has features for setting up the necessary K8s resources and for interactig with a cluster. It runs kustomize to generate the K8s resources.
+The tests use a framework that has features for setting up the necessary K8s resources and for interacting with a cluster. It runs kustomize to generate the K8s resources.
 
 ### How to run tests
 
@@ -14,26 +14,26 @@ The tests use a framework that has features for setting up the necessary K8s res
 
 If you don't already have a Kubernetes cluster running check the steps from the repository readme to create one. The following steps assume a local kind cluster is up and running.
 
-The e2e test can be run with the `e2e-test` makefile target, it will first build the required images and load them in kind.
+1. Build images for the operator and Redis
 
 ```
-make e2e-test
+make e2e-test-setup
 ```
 
-`go test` can be used directly to avoid rebuilding the images and just run the test code
+2. Run the e2e tests
 
 ```
 cd test/e2e
-go test -tags=e2e_redis_op
+go test -tags=e2e_redis_op -count=1
 ```
 
-TODO
+*It is important to add the `-count=1` flag otherwise the test resutls will be cached between multiple runs with unexpected results*
 
 ---
 
 ### Developing tests
 
-The testsuite and framework are kept behind a build tag and are only compiled and included in the binary if the tag is provided.
+The test suite and framework are kept behind a build tag and are only compiled and included in the binary if the tag is provided.
 
 If using Neovim with CoC `gopls` checks can be enabled from `coc-settings.json` with:
 

--- a/test/e2e/errcheck.go
+++ b/test/e2e/errcheck.go
@@ -1,0 +1,7 @@
+package e2e
+
+func Check(err error, fn func(string, ...interface{}), msg string) {
+	if err != nil {
+		fn("%s: %v", msg, err)
+	}
+}

--- a/test/e2e/rediscluster_test.go
+++ b/test/e2e/rediscluster_test.go
@@ -6,33 +6,162 @@ import (
 	"fmt"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	// "k8s.io/apimachinery/pkg/version"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/PayU/Redis-Operator/test/framework"
 )
 
-func TestRedisCreateDeleteCluster(t *testing.T) {
+func testCreateDeleteRedisCluster(t *testing.T) {
 
 	fmt.Printf("Running test %s\n", t.Name())
-	fmt.Println("Server version: ", tfw.K8sServerVersion)
 
 	ctx := framework.NewTestCtx(t, t.Name())
-	defer ctx.Cleanup(t)
+	defer ctx.Cleanup()
 
 	// create namespace, roles, rolebindings and CRD
-	if err := tfw.InitializeDefaultResources(&ctx, defaultConfig.KustomizePath,
-		defaultConfig.OperatorImage, defaultConfig.TestTimeout); err != nil {
-		t.Fatalf("Failed to initialize resources %v", err)
-	}
+	err := tfw.InitializeDefaultResources(&ctx, defaultConfig.KustomizePath,
+		defaultConfig.OperatorImage,
+		defaultConfig.RedisClusterSetupTimeout)
+	Check(err, t.Fatalf, "Failed to initialize resources")
 
-	redisCluster, err := tfw.CreateRedisCluster(&ctx, defaultConfig.TestTimeout)
-	if err != nil {
-		t.Fatalf("Failed to create Redis cluster resource %v", err)
-	}
+	fmt.Println("[E2E] Finished creating default resources")
+
+	redisCluster, err := tfw.MakeRedisCluster(defaultConfig.RedisClusterYAMLPath)
+	Check(err, t.Fatalf, "Failed to make Redis cluster resource")
+
+	err = tfw.CreateRedisClusterAndWaitUntilReady(&ctx, redisCluster, defaultConfig.RedisClusterSetupTimeout)
+	Check(err, t.Fatalf, "Failed to create Redis cluster")
+
+	fmt.Println("[E2E] Finished creating redis cluster")
 
 	ctx.PopFinalizer() // removing the Redis finalizer from the context since it is deleted bellow
-	if err = tfw.DeleteRedisCluster(redisCluster); err != nil {
-		t.Fatalf("Failed to delete Redis cluster %v", err)
-	}
-	// TODO wait until all resources are out of 'terminating'
+	err = tfw.DeleteRedisCluster(redisCluster, defaultConfig.RedisClusterSetupTimeout)
+	Check(err, t.Fatalf, "Failed to delete Redis cluster")
+
+	fmt.Println("[E2E] Finished deleting redis cluster")
 }
 
-func TestRedisClusterAvailabilityZoneDistribution(t *testing.T) {}
+func TestRedisClusterAvailabilityZoneDistribution(t *testing.T) {
+
+	fmt.Printf("---\n[E2E] Running test: %s\n", t.Name())
+
+	ctx := framework.NewTestCtx(t, t.Name())
+	defer ctx.Cleanup()
+
+	// the availability zone label differs between K8s 1.17+ and older
+	// https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone
+	var zoneLabel string
+
+	if tfw.K8sServerVersion.String() < "v1.17" {
+		zoneLabel = "failure-domain.beta.kubernetes.io/zone"
+	} else {
+		zoneLabel = "topology.kubernetes.io/zone"
+	}
+
+	err := tfw.InitializeDefaultResources(&ctx, defaultConfig.KustomizePath,
+		defaultConfig.OperatorImage, defaultConfig.RedisClusterSetupTimeout)
+	Check(err, t.Fatalf, "Failed to initialize resources")
+
+	ns := tfw.KustomizeConfig.Namespace
+
+	redisCluster, err := tfw.MakeRedisCluster(defaultConfig.RedisClusterYAMLPath)
+	Check(err, t.Fatalf, "Failed to make Redis cluster resource")
+
+	fmt.Println("[E2E] Creating redis cluster...")
+
+	err = tfw.CreateRedisClusterAndWaitUntilReady(&ctx, redisCluster, defaultConfig.RedisClusterSetupTimeout)
+	Check(err, t.Fatalf, "Failed to create Redis cluster")
+
+	fmt.Println("[E2E] Finished creating redis cluster")
+
+	nodes, err := tfw.GetNodes()
+	Check(err, t.Fatalf, "Failed to get Kubernetes nodes")
+
+	// AZ map with structure Map[AZ][leaderId] -> pod list
+	azMap := make(map[string]map[string]([]*corev1.Pod))
+
+	for _, node := range nodes.Items {
+		opts := []client.ListOption{
+			client.InNamespace(ns.Name),
+			client.MatchingFields{"spec.nodeName": node.Name},
+		}
+
+		leaders, err := tfw.GetRedisPods("leader", opts...)
+		Check(err, t.Fatalf, "Failed to get leader nodes")
+
+		followers, err := tfw.GetRedisPods("follower", opts...)
+		Check(err, t.Fatalf, "Failed to get follower nodes")
+
+		if len(leaders.Items) == 0 && len(followers.Items) == 0 {
+			continue
+		}
+
+		if len(leaders.Items)+len(followers.Items) > 1 {
+			t.Error("Pod distribution error - found more then one Redis pod on the same node")
+		}
+
+		az, foundAZ := azMap[node.Labels[zoneLabel]]
+		if !foundAZ {
+			az = make(map[string]([]*corev1.Pod))
+		}
+
+		for _, pod := range leaders.Items {
+			group, found := az[pod.Labels["leader-number"]]
+			if !found {
+				group = []*corev1.Pod{&pod}
+			} else {
+				group = append(group, &pod)
+			}
+			az[pod.Labels["leader-number"]] = group
+		}
+
+		for _, pod := range followers.Items {
+			group, found := az[pod.Labels["leader-number"]]
+			if !found {
+				group = []*corev1.Pod{&pod}
+			} else {
+				group = append(group, &pod)
+			}
+			az[pod.Labels["leader-number"]] = group
+		}
+
+		azMap[node.Labels[zoneLabel]] = az
+	}
+
+	// check if any AZ has two leaders or two nodes from the same Redis group
+	for az, groups := range azMap {
+		leaderCount := 0
+		for leaderID, pods := range groups {
+			for _, pod := range pods {
+				if pod.Labels["redis-node-role"] == "leader" {
+					leaderCount++
+				}
+			}
+			if len(pods) > 1 {
+				t.Errorf("The group with leader ID %s has %d nodes in %s\n", leaderID, len(pods), az)
+			}
+		}
+		if leaderCount > 1 {
+			t.Errorf("Found more then one leader in %s\n", az)
+		}
+	}
+	printAZMap(azMap)
+}
+
+func printAZMap(azMap map[string]map[string][]*corev1.Pod) {
+	fmt.Println("*** Redis cluster AZ map")
+	for az, groups := range azMap {
+		fmt.Printf("%s\n", az)
+		for leaderID, pods := range groups {
+			fmt.Printf("Group [%s]:", leaderID)
+			for _, pod := range pods {
+				fmt.Printf(" %s", pod.Name)
+			}
+			fmt.Println()
+		}
+		fmt.Println()
+	}
+}

--- a/test/e2e/testconfigs.go
+++ b/test/e2e/testconfigs.go
@@ -5,15 +5,19 @@ package e2e
 import "time"
 
 type TestConfig struct {
-	KustomizePath string
-	OperatorImage string
-	TestTimeout   time.Duration
+	KustomizePath            string
+	OperatorImage            string
+	RedisClusterYAMLPath     string
+	K8sResourceSetupTimeout  time.Duration // used for general resources such as roles and deployments
+	RedisClusterSetupTimeout time.Duration // used for the Redis cluster creations
 }
 
 var (
 	defaultConfig = TestConfig{
-		KustomizePath: "../../config/default",
-		OperatorImage: "redis-operator-docker:local",
-		TestTimeout:   20 * time.Second,
+		KustomizePath:            "../../config/default",
+		OperatorImage:            "redis-operator-docker:local",
+		RedisClusterYAMLPath:     "../../config/samples/local_cluster.yaml",
+		K8sResourceSetupTimeout:  20 * time.Second,
+		RedisClusterSetupTimeout: 120 * time.Second,
 	}
 )

--- a/test/framework/context.go
+++ b/test/framework/context.go
@@ -4,6 +4,9 @@ package framework
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"testing"
 
 	"golang.org/x/sync/errgroup"
@@ -12,26 +15,32 @@ import (
 type TestCtx struct {
 	ID         string
 	cleanUpFns []finalizerFn
+	testHandle *testing.T
 }
 
 type finalizerFn func() error
 
 func NewTestCtx(t *testing.T, name string) TestCtx {
-	return TestCtx{
-		ID: name,
+	ctx := TestCtx{
+		ID:         name,
+		testHandle: t,
 	}
+
+	ctx.SetupSignalHandler()
+
+	return ctx
 }
 
-func (ctx *TestCtx) Cleanup(t *testing.T) {
+func (ctx *TestCtx) Cleanup() {
 	var eg errgroup.Group
-	fmt.Println("\nRunning cleanup")
+	fmt.Println("[E2E] Cleanup")
 
 	for i := len(ctx.cleanUpFns) - 1; i >= 0; i-- {
 		eg.Go(ctx.cleanUpFns[i])
 	}
 
 	if err := eg.Wait(); err != nil {
-		t.Fatal(err)
+		ctx.testHandle.Fatal(err)
 	}
 }
 
@@ -43,4 +52,14 @@ func (ctx *TestCtx) PopFinalizer() {
 	if len(ctx.cleanUpFns) > 0 {
 		ctx.cleanUpFns = ctx.cleanUpFns[:len(ctx.cleanUpFns)-1]
 	}
+}
+
+func (ctx *TestCtx) SetupSignalHandler() {
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		ctx.Cleanup()
+		ctx.testHandle.Fatal("Test interrupted by SIGTERM")
+	}()
 }

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -3,6 +3,8 @@
 package framework
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -31,6 +33,7 @@ type Framework struct {
 	KubeClient       kubernetes.Interface
 	ExtentionClient  apiextclient.Interface
 	RedisCLI         *rediscli.RedisCLI
+	KustomizeConfig  *KustomizeConfig
 }
 
 // A new framework instance is initialised with a cluster configuration that
@@ -73,6 +76,8 @@ func NewFramework(kubeconfig, opImage string) (*Framework, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get Kubernetes server version")
 	}
+
+	fmt.Printf("[E2E] Kubernetes server version: %s\n", serverVersion)
 
 	return &Framework{
 		RuntimeClient:    cli,

--- a/test/framework/rediscluster.go
+++ b/test/framework/rediscluster.go
@@ -1,0 +1,92 @@
+// +build e2e_redis_op
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	dbv1 "github.com/PayU/Redis-Operator/api/v1"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// GetRedisPods gets the Redis pods of a given type. The type of the pod requested can be
+// one of "follower", "leader" or "any".
+func (f *Framework) GetRedisPods(podType string, opts ...client.ListOption) (*corev1.PodList, error) {
+	matchingLabels := client.MatchingLabels{
+		"app": "redis",
+	}
+	if podType != "any" {
+		if podType != "leader" && podType != "follower" {
+			fmt.Printf("[E2E][WARN] Using custom Redis role: %s\n", podType)
+		}
+		matchingLabels["redis-node-role"] = podType
+	}
+	opts = append(opts, matchingLabels)
+	return f.GetPods(opts...)
+}
+
+// MakeRedisCluster returns the object for a RedisCluster
+func (f *Framework) MakeRedisCluster(filePath string) (*dbv1.RedisCluster, error) {
+	redisCluster := &dbv1.RedisCluster{}
+	yamlRes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not read the Redis cluster YAML resource")
+	}
+	if err = yaml.Unmarshal(yamlRes, &redisCluster); err != nil {
+		return nil, errors.Wrap(err, "Could not unmarshal the Redis cluster YAML resource")
+	}
+	return redisCluster, nil
+}
+
+// CreateRedisCluster creates the Redis cluster inside a K8s cluster
+func (f *Framework) CreateRedisCluster(ctx *TestCtx, redisCluster *dbv1.RedisCluster, timeout time.Duration) error {
+	if err := f.CreateResource(ctx, redisCluster, timeout); err != nil {
+		return errors.Wrap(err, "Could not create the Redis cluster resource")
+	}
+	return nil
+}
+
+func (f *Framework) CreateRedisClusterAndWaitUntilReady(ctx *TestCtx, redisCluster *dbv1.RedisCluster, timeout time.Duration) error {
+	buf := dbv1.RedisCluster{}
+	if err := f.CreateRedisCluster(ctx, redisCluster, timeout); err != nil {
+		return err
+	}
+
+	if timeout == 0 {
+		return nil
+	}
+
+	key, err := client.ObjectKeyFromObject(redisCluster)
+	if err != nil {
+		return errors.Wrap(err, "Could not create resource - object key error")
+	}
+
+	err = wait.PollImmediate(2*time.Second, timeout, func() (bool, error) {
+		if err = f.RuntimeClient.Get(context.TODO(), key, &buf); err != nil {
+			return false, err
+		}
+		if string(buf.Status.ClusterState) != "Ready" {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return errors.Wrap(err, "Creation of Redis cluster timed out")
+	}
+
+	return nil
+}
+
+func (f *Framework) DeleteRedisCluster(obj runtime.Object, timeout time.Duration) error {
+	return f.DeleteResource(obj, timeout)
+}


### PR DESCRIPTION
* Added framework functionality for creating the Redis cluster
* Added e2e test for AZ awareness functionality
* Added handling for kubectl warning message
* Added handling for SIGTERM signal in case the test is aborted by user
* Improved the cleanup process
* Changed Kubernetes version for the `kind` cluster to `1.16.15`

closes #18 