### PR TITLE
Add CLUSTER FAILOVER feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.so
 *.dylib
 bin
-manager
+/manager
 
 
 # Test binary, build with `go test -c`
@@ -31,7 +31,7 @@ manager
 !.vscode/extensions.json
 .history/
 *.orig
-kubeconfig.yaml
+*kubeconfig.yaml
 
 telepresence.log
 Redis-Operator

--- a/controllers/rediscli/redis_cli.go
+++ b/controllers/rediscli/redis_cli.go
@@ -206,3 +206,29 @@ func (r *RedisCLI) GetLeaderReplicas(nodeIP string, leaderNodeID string) (*Leade
 
 	return NewLeaderReplicas(stdout, r.Log), err
 }
+
+// https://redis.io/commands/cluster-failover
+func (r *RedisCLI) ClusterFailover(nodeIP string, opt ...string) (string, error) {
+	r.Log.Info(fmt.Sprintf("executing cluster failover on [%s]", nodeIP))
+	args := []string{"-h", nodeIP, "cluster", "failover"}
+
+	if len(opt) != 0 {
+		if strings.ToLower(opt[0]) != "force" && strings.ToLower(opt[0]) != "takeover" {
+			r.Log.Info(fmt.Sprintf("Warning: CLUSTER FALOVER called with wrong option - %s", opt[0]))
+		} else {
+			args = append(args, opt[0])
+		}
+	}
+
+	stdout, err := r.executeCommand(args)
+	if err != nil {
+		r.Log.Error(err, "unable to get cluster nodes using redis-cli")
+		return "", err
+	}
+
+	stdout = strings.TrimSpace(stdout)
+	if stdout != "OK" {
+		r.Log.Info(fmt.Sprintf("Warning: CLUSTER FAILOVER returned %s", stdout))
+	}
+	return stdout, nil
+}

--- a/controllers/rediscli/redis_info.go
+++ b/controllers/rediscli/redis_info.go
@@ -57,12 +57,12 @@ func NewRedisInfo(rawInfo string) *RedisInfo {
 		return nil
 	}
 	lines := strings.Split(rawInfo, "\n")
-	currentLine := 0
 	info := RedisInfo{}
-	for currentLine < len(lines) {
-		if lines[currentLine] != "" {
-			if lines[currentLine][0] == '#' {
-				currentInfoLabel = lines[currentLine][2:]
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			if line[0] == '#' {
+				currentInfoLabel = strings.TrimSpace(line[2:])
 				switch currentInfoLabel {
 				case "Server":
 					info.Server = make(map[string]string)
@@ -96,11 +96,10 @@ func NewRedisInfo(rawInfo string) *RedisInfo {
 					currentInfo = &info.Keyspace
 				}
 			} else {
-				lineInfo := strings.Split(lines[currentLine], ":")
+				lineInfo := strings.Split(line, ":")
 				(*currentInfo)[lineInfo[0]] = lineInfo[1]
 			}
 		}
-		currentLine++
 	}
 	return &info
 }


### PR DESCRIPTION
- Added the CLUSTER FAILOVER command to redis-cli wrapper
- Fixed a bug in the parser for INFO command output
- Renamed all the 'redisOperator' parameters to 'redisCluster'