### PR TITLE
Add E2E test for connectivity issues

### DIFF
--- a/hack/cloud.yaml
+++ b/hack/cloud.yaml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: 10.10.10.0/24
 nodes:
 - role: control-plane
   image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20

--- a/hack/gen_kind_config.py
+++ b/hack/gen_kind_config.py
@@ -28,6 +28,9 @@ def get_node_configs():
 def get_config_header():
     return f'''kind: Cluster
 apiVersion: {ClusterParams.KIND_API_VERSION}
+networking:
+  disableDefaultCNI: true
+  podSubnet: 10.10.10.0/24
 nodes:
 - role: control-plane
   image: kindest/node:{ClusterParams.KUBERNETES_VERSION}

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,4 +1,5 @@
 CLUSTER_NAME=redis-test
+CALICO_VERSION=v3.17
 
 python3 gen_kind_config.py
 kind create cluster --name $CLUSTER_NAME --config cloud.yaml
@@ -7,10 +8,12 @@ kind --name $CLUSTER_NAME get kubeconfig > "$CLUSTER_NAME.kubeconfig.yaml"
 current_context=$(kubectl config current-context)
 if [ "$current_context" = "kind-$CLUSTER_NAME" ]; then
   kubectl create -f ns.yaml
+  # install the Calico CNI
+  kubectl apply -f "https://docs.projectcalico.org/$CALICO_VERSION/manifests/calico.yaml"
+  kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
   # add metrics server to the cluster
   kubectl apply -f addons/metrics-server.yaml
   kubectl patch deployment metrics-server -n kube-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"metrics-server","args":["--cert-dir=/tmp", "--secure-port=4443", "--kubelet-insecure-tls","--kubelet-preferred-address-types=InternalIP"]}]}}}}'
 else
-  echo "Please set the current cluster config to kind-redis-test and run"
-  echo "kubectl create -f ns.yaml"
+  echo "Please set the current cluster context to kind-$CLUSTER_NAME and re-run the install script"
 fi

--- a/hack/np.yaml
+++ b/hack/np.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: infra
+spec:
+  podSelector:
+    matchLabels:
+      node-number: "3"
+  policyTypes:
+  - Ingress
+  - Egress

--- a/test/e2e/rediscluster_test.go
+++ b/test/e2e/rediscluster_test.go
@@ -232,7 +232,7 @@ func testRollingUpdate(t *testing.T) {
 2. Drain all nodes of an availability zone
 3. Reenable the node scheduling and wait for Redis cluster to recover
 */
-func TestAZFailure(t *testing.T) {
+func testAZFailure(t *testing.T) {
 	fmt.Printf("---\n[E2E] Running test: %s\n", t.Name())
 	ctx := framework.NewTestCtx(t, t.Name())
 	defer ctx.Cleanup()
@@ -273,4 +273,16 @@ func TestAZFailure(t *testing.T) {
 	azMap := makeAZMap(&ctx, t)
 	printAZMap(azMap)
 	checkAZCorrectness(azMap, t)
+}
+
+/*
+1. Create a default cluster
+2. During cluster setup drop the cluster connectivity on each of the RedisCluster states
+3. Check that the RedisCluster reaches ready state with correct AZ distribution
+*/
+func TestConnectivityDrop(t *testing.T) {
+	fmt.Printf("---\n[E2E] Running test: %s\n", t.Name())
+	ctx := framework.NewTestCtx(t, t.Name())
+	defer ctx.Cleanup()
+	// TODO
 }

--- a/test/framework/rediscluster.go
+++ b/test/framework/rediscluster.go
@@ -11,6 +11,9 @@ import (
 	dbv1 "github.com/PayU/Redis-Operator/api/v1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -104,4 +107,23 @@ func (f *Framework) WaitForState(redisCluster *dbv1.RedisCluster, state string, 
 		}
 		return false, nil
 	})
+}
+
+// DropNodeConnection stops traffic for a specified Redis node
+// redisNodeNumber: node number label assigned at creation time
+// policyType: 			one of 'ingress', 'egress' or 'ingress,egress'
+// timeout:					time to wait for NetworkPolicy resource creation
+func (f *Framework) DropNodeConnection(ctx *TestCtx, redisNodeNumber string, policyType string, timeout time.Duration) (*networkingv1.NetworkPolicy, error) {
+	np := f.MakeNetworkPolicy(&metav1.LabelSelector{MatchLabels: map[string]string{"node-number": redisNodeNumber}}, nil, nil)
+	err := f.CreateResource(ctx, &np, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// DropNamespaceConnection stops network traffic for all pods in a namespace
+// policyType: one of 'ingress', 'egress' or 'ingress,egress'
+func (f *Framework) DropNamespaceConnection(namespace string, policyType string) (*networkingv1.NetworkPolicy, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Findings during testing:

- The NetworkPolicy can block all traffic between the controller pod and the Redis pods (this will not trigger a reconcile loop) but it will not block the gossiping between nodes.

Linked to #35 