### PR TITLE
Enable leader election

### DIFF
--- a/config/manager/base/manager.yaml
+++ b/config/manager/base/manager.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()


### PR DESCRIPTION
- Increased the number of manager pods from 1 to 2
- Enabled leader election

closes #41 