### PR TITLE
fix: make sure redis-node is fully sync before failover

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -11,6 +11,7 @@ import (
 type RedisClusterState string
 
 const (
+	loadTimeInterval      = 500 * time.Millisecond
 	genericCheckInterval  = 2 * time.Second
 	genericCheckTimeout   = 50 * time.Second
 	clusterCreateInterval = 5 * time.Second

--- a/controllers/redis_node_config.go
+++ b/controllers/redis_node_config.go
@@ -218,9 +218,9 @@ var redisConf = `
     #
     #   save ""
 
-    save 900 1
-    save 300 10
-    save 60 10000
+    # save 900 1
+    # save 300 10
+    # save 60 10000
 
     # By default Redis will stop accepting writes if RDB snapshots are enabled
     # (at least one save point) and the latest background save failed.
@@ -699,7 +699,7 @@ var redisConf = `
     #
     # Please check http://redis.io/topics/persistence for more information.
 
-    appendonly yes
+    appendonly no
 
     # The name of the append only file (default: "appendonly.aof")
 

--- a/controllers/rediscluster.go
+++ b/controllers/rediscluster.go
@@ -312,7 +312,12 @@ func (r *RedisClusterReconciler) replicateLeader(followerIP string, leaderIP str
 	}
 
 	r.Log.Info(fmt.Sprintf("Replication successful"))
-	return r.waitForRedisReplication(leaderIP, leaderID, followerID)
+
+	if err = r.waitForRedisReplication(leaderIP, leaderID, followerID); err != nil {
+		return err
+	}
+
+	return r.waitForRedisSync(followerIP)
 }
 
 // Changes the role of a leader with one of its followers


### PR DESCRIPTION
- Logic change on master failover process: make sure promoted follower is fully sync and loaded before starting a manual failover
- add waitForRedisLoad function: make sure loading process is finished on a fresh node
- Verify follower node is fully sync before continue to the next one (in replicateLeader function)
- Enhance manual failover logs

close #81 