### PR TITLE
Improve recovery during rolling update

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -78,6 +78,7 @@ func (r *RedisClusterReconciler) handleReadyState(redisCluster *dbv1.RedisCluste
 	uptodate, err := r.isClusterUpToDate(redisCluster)
 	if err != nil {
 		r.Log.Info("Could not check if cluster is updated")
+		redisCluster.Status.ClusterState = string(Recovering)
 		return err
 	}
 	if !uptodate {

--- a/controllers/rediscluster.go
+++ b/controllers/rediscluster.go
@@ -797,7 +797,6 @@ func (r *RedisClusterReconciler) waitForRedisLoad(nodeIP string) error {
 
 		loadStatusETA := redisInfo.GetLoadStatus()
 		if loadStatusETA == "" {
-			r.Log.Info(fmt.Sprintf("node %s still not started the loading process", nodeIP))
 			return false, nil
 		}
 


### PR DESCRIPTION
Added state transition for a failed cluster left in the updating state