### PR TITLE
Improve failover handling

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -11,7 +11,10 @@ import (
 type RedisClusterState string
 
 const (
-	loadTimeInterval      = 500 * time.Millisecond
+	syncCheckInterval     = 500 * time.Millisecond
+	syncCheckTimeout      = 10 * time.Second
+	loadCheckInterval     = 500 * time.Millisecond
+	loadCheckTimeout      = 10 * time.Second
 	genericCheckInterval  = 2 * time.Second
 	genericCheckTimeout   = 50 * time.Second
 	clusterCreateInterval = 5 * time.Second

--- a/controllers/rediscli/redis_cli.go
+++ b/controllers/rediscli/redis_cli.go
@@ -220,7 +220,7 @@ func (r *RedisCLI) ClusterReplicas(nodeIP string, leaderNodeID string) (*RedisCl
 func (r *RedisCLI) ClusterFailover(nodeIP string, opt ...string) (string, error) {
 	args := []string{"-h", nodeIP, "cluster", "failover"}
 
-	if len(opt) != 0 {
+	if len(opt) != 0 && opt[0] != "" {
 		if strings.ToLower(opt[0]) != "force" && strings.ToLower(opt[0]) != "takeover" {
 			r.Log.Info(fmt.Sprintf("Warning: CLUSTER FALOVER called with wrong option - %s", opt[0]))
 		} else {

--- a/controllers/rediscli/redis_info.go
+++ b/controllers/rediscli/redis_info.go
@@ -164,16 +164,15 @@ func (r *RedisClusterInfo) IsClusterFail() bool {
 	return (*r)["cluster_state"] == "fail"
 }
 
-// GetLoadStatus indicating if the load of a dump file is on-going
+// GetLoadETA indicating if the load of a dump file is on-going
 // If a load operation is on-going, it returns the ETA to finish.
-func (r *RedisInfo) GetLoadStatus() string {
+func (r *RedisInfo) GetLoadETA() string {
 	if r.Persistence["loading"] != "0" {
 		eta, found := r.Persistence["loading_eta_seconds"]
 		if found {
 			return eta
 		}
 	}
-
 	return ""
 }
 


### PR DESCRIPTION
- Added a failback mode for failover operation that uses takeover
- Fixed a bug causing the node cleanup method to be called too often
- Fixed a bug related to master nodes not being recreated
- Fixed a bug in the wait method of the SYNC process