### PR TITLE
Add support for Tilt development flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 bin
 /manager
 /redis-operator
+/hack/redis-bin/build
 
 # Test binary, build with `go test -c`
 *.test
@@ -33,4 +34,5 @@ bin
 *.orig
 *kubeconfig.yaml
 
+**/tilt_modules/*
 telepresence.log

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Examples:
 helm install redis-operator ./helm -n default
 
 # install only the Redis operator in the default namespace
-helm install redis-operator ./helm -n default --set global.rbac.create=false redisCluster.enabled=false --skip-crds
+helm install redis-operator ./helm -n default --set global.rbac.create=false --set redisCluster.enabled=false --skip-crds
 
 # install only the RBAC configuration (Role+Binding, ClusterRole+Binding, ServiceAccount)
-helm install redis-operator-rbac ./helm -n default --set redisOperator=false redisCluster.enabled=false --skip-crds
+helm install redis-operator-rbac ./helm -n default --set redisOperator=false --set redisCluster.enabled=false --skip-crds
 
 #install only the RedisCluster in the default namespace
-helm install redis-operator-rbac ./helm -n default --set redisOperator=false global.rbac.create=false --skip-crds
+helm install redis-operator-rbac ./helm -n default --set redisOperator=false --set global.rbac.create=false --skip-crds
 ```
 
 ### Running the E2E tests
@@ -74,14 +74,38 @@ Check the README on how to use E2E tests: [https://github.com/PayU/redis-operato
 
 ### Running unit tests
 
-Run non cache `go test` command on specific path. for example:  
+Run non cache `go test` command on specific path. for example:
 ```
 go test -count=1 ./controllers/rediscli/
 ```
 
+### Development using Tilt
+
+The recommended development flow is based on [Tilt](https://tilt.dev/) - it is used for quick iteration on code running in live containers.
+Setup based on [official docs](https://docs.tilt.dev/example_go.html) can be found in the Tiltfile.
+
+Prerequisites:
+
+1. Install the Tilt tool
+2. Build the redis-cli binary: go to `hack/redis-bin` and run the `run.sh` script. It will build the redis-cli binary inside a Linux container so it can be used by Tilt when building the dev image. You only need to do this once. Check that you have redis-cli in `hack/redis-bin/build` directory.
+3. Run `tilt up` and go the indicated localhost webpage
+
+```
+> tilt up
+Tilt started on http://localhost:10350/
+v0.22.15, built 2021-10-29
+
+(space) to open the browser
+(s) to stream logs (--stream=true)
+(t) to open legacy terminal mode (--legacy=true)
+(ctrl-c) to exit
+```
+
 ---
 
-### Quick development using Telepresence
+### Development using Telepresence
+
+*The Telepresence setup is deprecated, it only works with telepresence V1 and will be remvoved once the Tilt flow is fully adopted.*
 
 To develop directly on a deployed operator without rebuilding and loading/deploying the image you need to have access to a cluster (can be remote or local) and [Telepresence](https://www.telepresence.io/) tool.
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,84 @@
+load('ext://restart_process', 'docker_build_with_restart')
+
+if k8s_context() != 'kind-redis-test':
+  fail('Expected K8s context to be "kind-redis-cluster", found: ' + k8s_context())
+
+# local_resource('build-redis', './hack/redis-bin/run.sh')
+
+compile_cmd = 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o bin/manager main.go'
+local_resource(
+  'redis-operator-compile',
+  compile_cmd,
+  deps=['./main.go', './api', './controllers', './server']
+)
+
+docker_build(
+  ref='metrics-exporter:testing',
+  context='./hack',
+  dockerfile='./hack/metrics-exporter.Dockerfile',
+)
+
+docker_build(
+  ref='redis-init:testing',
+  context='./hack',
+  dockerfile='./hack/redis-init.Dockerfile',
+)
+
+docker_build(
+  ref='redis:testing',
+  context='./hack',
+  dockerfile='./hack/redis.Dockerfile',
+)
+
+docker_build_with_restart(
+  'redis-operator-docker',
+  '.',
+  entrypoint='/manager',
+  ignore=['./bin/manager-go-tmp-umask'],
+  dockerfile='tilt.Dockerfile',
+  only=[
+    './hack/redis-bin/build/redis-cli',
+    './bin',
+  ],
+  live_update=[
+    sync('./bin/manager', '/manager'),
+  ],
+)
+
+k8s_yaml('./helm/crds/crd-rediscluster.yaml')
+k8s_yaml(local('helm template ./helm --name-template=redis-operator -n default --set redisOperator.managerReplicas=1'))
+
+k8s_resource(
+  new_name='redis-cluster-crd',
+  objects=['redisclusters.db.payu.com:customresourcedefinition'],
+)
+
+k8s_kind('RedisCluster',
+  image_json_path=[
+    '{.spec.redisPodSpec.containers[0].image}',
+    '{.spec.redisPodSpec.containers[1].image}',
+    '{.spec.redisPodSpec.initContainers[0].image}',
+])
+# k8s_resource(
+#   new_name='redis-cluster',
+#   objects=['dev-rdc:rediscluster'],
+#   extra_pod_selectors=[{'redis-cluster': 'dev-rdc'}],
+#   resource_deps=['redis-cluster-crd'],
+# )
+
+k8s_resource(
+  new_name='redis-operator-config',
+  objects=[
+    'redis-operator-manager:serviceaccount',
+    'redis-operator:role', 'redis-operator:rolebinding',
+    'redis-operator:clusterrole', 'redis-operator:clusterrolebinding',
+    'dev-rdc-users-acl:configmap',
+    'dev-rdc-redisconfig:configmap',
+    'redis-operator-config:configmap',],
+)
+
+k8s_resource(workload='redis-operator-manager', port_forwards=[
+    port_forward(8080, 8080, "api-server"),
+    port_forward(8081, 9808, "metrics"),],
+  resource_deps=['redis-cluster-crd', 'redis-operator-config', 'redis-operator-compile']
+)

--- a/hack/cloud.yaml
+++ b/hack/cloud.yaml
@@ -26,22 +26,6 @@ nodes:
     kind: JoinConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1a"
-- role: worker
-  image: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1b"
-- role: worker
-  image: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1b"
 - role: worker
   image: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
@@ -67,12 +51,3 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1c"
-- role: worker
-  image: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "failure-domain.beta.kubernetes.io/zone=eu-central-1c"
-

--- a/hack/dev.Dockerfile
+++ b/hack/dev.Dockerfile
@@ -10,10 +10,9 @@ WORKDIR /workspace
 
 # install curl
 RUN apt-get update \
-    && apt-get install -y curl \
-    && apt-get install xz-utils 
+    && apt-get install -y curl
 
-RUN curl -OLJs https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz | xz
+RUN curl -LJs https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz | tar xz
 ENV KUBEBUILDER_ASSETS=/workspace/kubebuilder_2.3.1_linux_amd64/bin
 
 # install redis cli

--- a/hack/gen_kind_config.py
+++ b/hack/gen_kind_config.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 class ClusterParams:
     CONFIG_FILENAME = 'cloud.yaml'
-    NODE_LAYOUT = [['eu-central-1a']*3, ['eu-central-1b']*3, ['eu-central-1c']*3]
+    NODE_LAYOUT = [['eu-central-1a']*2, ['eu-central-1b']*2, ['eu-central-1c']*2]
     ZONE_KEY = 'failure-domain.beta.kubernetes.io/zone'
     KIND_API_VERSION = 'kind.x-k8s.io/v1alpha4'
     KUBERNETES_VERSION = 'v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c'

--- a/hack/redis-bin/Dockerfile
+++ b/hack/redis-bin/Dockerfile
@@ -1,0 +1,11 @@
+# should build the redis binary with the same image that the operator will run
+FROM golang:1.15
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /
+RUN apt-get update && apt-get install -y curl
+COPY build-redis.sh /build-redis.sh
+RUN mkdir /redis
+
+ENTRYPOINT ["./build-redis.sh"]

--- a/hack/redis-bin/README.md
+++ b/hack/redis-bin/README.md
@@ -1,0 +1,1 @@
+Execute the `run.sh` script to build the redis-cli binary. The binary is built inside a Linux container, you should use the same base image as the one used for the operator.

--- a/hack/redis-bin/build-redis.sh
+++ b/hack/redis-bin/build-redis.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+REDIS_VERSION=6.2.6
+
+cd /redis
+curl -LJs https://github.com/redis/redis/archive/refs/tags/$REDIS_VERSION.tar.gz | tar xz
+
+make -C redis-$REDIS_VERSION
+cp redis-$REDIS_VERSION/src/redis-cli .

--- a/hack/redis-bin/run.sh
+++ b/hack/redis-bin/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ -d "build" ]]
+then
+  echo "found redis build dir"
+  exit 0
+fi
+
+echo "Building redis..."
+docker build . -t redis-builder:dev
+docker run --rm -v $(pwd)/build:/redis redis-builder:dev

--- a/tilt.Dockerfile
+++ b/tilt.Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.15
+WORKDIR /
+ADD hack/redis-bin/build/redis-cli /bin/redis-cli
+ADD bin/manager /manager
+ENTRYPOINT manager


### PR DESCRIPTION
- Added Tiltfile for development flow on local Kind cluster
- Reduced the size of the local kind cluster to 2 nodes per AZ
- Moved the build of redis-cli binary outside of the Dockerfile
- Small fixes to the makefile