### PR TITLE
Support clusterinfo miss-alignments / parsing issues detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ fmt:
 
 # Run go vet against code
 vet:
-	go vet ./...
+	export GOOS=linux ; go vet ./...
 
 # Generate code
 generate: controller-gen

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ e2e-test-setup: docker-build-operator docker-build-local-redis docker-build-loca
 
 # Build manager binary
 manager: generate fmt vet
-	go build -o bin/manager main.go
+	export GOOS=linux ; go build -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests

--- a/controllers/rediscli/cli_test.go
+++ b/controllers/rediscli/cli_test.go
@@ -7,6 +7,14 @@ import (
 
 type TestCommandHandler struct{}
 
+func (r *TestCommandHandler) buildRedisInfoModel(stdoutInfo string) (*RedisInfo, error) {
+	return &RedisInfo{}, nil
+}
+
+func (h *TestCommandHandler) buildRedisClusterInfoModel(stdoutInfo string) (*RedisClusterInfo, error) {
+	return &RedisClusterInfo{}, nil
+}
+
 func (h *TestCommandHandler) buildCommand(routingPort string, args []string, auth *RedisAuth, opt ...string) ([]string, map[string]string) {
 	if auth != nil {
 		args = append([]string{"--user", auth.User}, args...)
@@ -40,10 +48,10 @@ func resultHandler(expected string, result string, testCase string, argMap map[s
 	msg := "[CLI Unit test]\nExpected result : " + expected + "\nActual result   : " + result
 	msg += "\nExpected arg mapping result:\n" + mapToPrintableStr(expectedArgMap) + "Arg mapping result:\n" + mapToPrintableStr(argMap)
 	if strings.Compare(strings.TrimSpace(expected), strings.TrimSpace(result)) != 0 {
-		msg += "Test case " + testCase + " failed"
+		msg += "Test case " + testCase + " failed" + "\n\n"
 		t.Errorf(msg)
 	} else {
-		msg += "Test case " + testCase + " passed"
+		msg += "Test case " + testCase + " passed" + "\n\n"
 		t.Logf(msg)
 	}
 }

--- a/controllers/rediscli/info.go
+++ b/controllers/rediscli/info.go
@@ -3,6 +3,8 @@ package rediscli
 import (
 	"regexp"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // https://redis.io/commands/info
@@ -36,11 +38,39 @@ type RedisClusterNode struct {
 	LinkState   string
 }
 
-func NewRedisInfo(rawInfo string) *RedisInfo {
+func validateRedisInfo(redisInfo *RedisInfo) error {
+	validator := map[string]bool{
+		"serverInfo":      redisInfo.Server != nil,
+		"clientsInfo":     redisInfo.Clients != nil,
+		"memoryInfo":      redisInfo.Memory != nil,
+		"persistInfo":     redisInfo.Persistence != nil,
+		"statsInfo":       redisInfo.Stats != nil,
+		"replicationInfo": redisInfo.Replication != nil,
+		"cpuInfo":         redisInfo.CPU != nil,
+		"clustersInfo":    redisInfo.Cluster != nil,
+		"modulesInfo":     redisInfo.Modules != nil,
+		"keyspaceInfo":    redisInfo.Keyspace != nil,
+	}
+	errStr := "Redis info bad format error - the following keys are missing: "
+	ok := true
+	for key, indicator := range validator {
+		if !indicator {
+			errStr += " " + key
+			ok = false
+		}
+	}
+	if ok {
+		return nil
+	} else {
+		return errors.Errorf(errStr)
+	}
+}
+
+func NewRedisInfo(rawInfo string) (*RedisInfo, error) {
 	var currentInfo *map[string]string
 	var currentInfoLabel string
 	if rawInfo == "" {
-		return nil
+		return nil, nil
 	}
 	lines := strings.Split(rawInfo, "\n")
 	info := RedisInfo{}
@@ -85,28 +115,29 @@ func NewRedisInfo(rawInfo string) *RedisInfo {
 				lineInfo := strings.Split(line, ":")
 				if len(lineInfo) > 1 {
 					(*currentInfo)[lineInfo[0]] = lineInfo[1]
+				} else {
+					return &info, errors.Errorf("info.go : Redis info parsing error, line doesn't match the format <property>:<value>")
 				}
 			}
 		}
 	}
-	return &info
+	return &info, validateRedisInfo(&info)
 }
 
-func NewRedisClusterInfo(rawData string) *RedisClusterInfo {
+func NewRedisClusterInfo(rawData string) (*RedisClusterInfo, error) {
 	if rawData == "" {
-		return nil
+		return nil, nil
 	}
-
 	info := RedisClusterInfo{}
 	lines := strings.Split(rawData, "\r\n")
 	for _, line := range lines {
 		lineInfo := strings.Split(line, ":")
 		if len(lineInfo) < 2 {
-			return nil
+			return nil, errors.Errorf("info.go : Redis cluster info parsing error, line doesn't match the format <property>:<value>")
 		}
 		info[lineInfo[0]] = lineInfo[1]
 	}
-	return &info
+	return &info, nil
 }
 
 // NewRedisClusterNodes is a constructor for RedisClusterNodes


### PR DESCRIPTION
Changes:
* Reids Info validation method added: Each currently known section will be checked for its property-map presence (level: nil or not), all currently supported sections are expected (if missing - error will be returned).
* Both RedisInfo anf RedisClusterInfo constructor methods will return error in case of inability to parse according to currently known format `<property>:<value>`.
* CommandHandler now supports two new methods - build info model & build cluster info model (one version is implemented for runtime flow and a different one for unit testing flow)


| Test | Time | 
| --- | --- | 
| E2E | 375.353s | 
| cli_test | 0.517s | 

Tested on:
K8s v1.18.19
MacOS 11.6

https://github.com/PayU/redis-operator/issues/123